### PR TITLE
Turn this more into a review of unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,178 +6,110 @@
 
 ## Introduction
 
-There are 3 levels of functional testing we want to consider when we build APIs
-with Spring:
-
-1. Unit Testing: as with all unit testing, this should focus on the smallest
-   possible "unit" of our functionality, which means it should not depend on or
-   test any of the functionality of the Spring framework, but instead focus on
-   the functionality of a specific method.
-2. Integration Testing: this phase of testing will start to bring in some of the
-   Spring framework functionality and wiring to make sure that the functionality
-   we implemented ourselves is properly integrated with the Spring framework.
-3. Acceptance Testing: this last phase of functional testing will make sure that
-   all the layers of our APIs are tested together and that the functionality
-   that is expected by the end users of our APIs functions properly.
-
-We will be looking at unit testing in this lesson.
-
-## Unit Testing
-
 It's important that we keep unit testing independent of the Spring framework for
 2 main reasons:
 
 1. As always, isolating the test to specific functionality makes it easier to
-   diagnose what's wrong when a test doesn't pass. In this way, the same
-   principles that we've discussed before for Unit Testing and TDD apply here.
+   diagnose what's wrong when a test doesn't pass.
 2. Additionally, we need to consider that the Spring Framework can be heavy and
-   takes some time to initialize. Having a a suite of tests that can run without
+   takes some time to initialize. Having a suite of tests that can run without
    any of the scaffolding associated with the Spring Framework means that they
    can be "cheap" to run, and therefore can run very frequently and integrated
    into a developer's day-to-day work with minimal impact on their velocity.
 
-Let's use `Spring Itinitializr` to create a basic version of a Spring Boot
-project:
+## Code Along: Create a Spring Project for Testing
 
-![Basic Spring Initializr](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-basic-initializr.png)
+Let's create a new Spring project to demonstrate testing within the Spring framework.
 
-The only dependency we need to add is `Spring Web`.
+1. Go to [https://start.spring.io/](https://start.spring.io/).
+2. Select the project properties.
+   1. Select "Maven Project", as we will use Maven as the build tool.
+   2. Select "Java" as the language.
+   3. Select the most recent version of Spring Boot 2. (Make sure it does not
+      have "SNAPSHOT" listed after it.)
+   4. Change the "Artifact" metadata field to "spring-testing-demo". (This
+      will update the "Name" and "Package name" metadata fields too).
+   5. Change the "Description" metadata field to "Demo for Testing".
+   6. Select the appropriate Java JDK version.
+3. Add dependencies.
+   1. Click "ADD DEPENDENCIES".
+   2. Search for "spring web".
+   3. Select "Spring Web" from the list.
+4. Click on the "Generate" button on the bottom. This will download a zip file
+   containing the Spring Boot Project.
+5. Unzip the archive and open it in IntelliJ or a preferred code editor.
 
-This gives us the following basic Spring Boot application:
+![Basic Spring Initializr](https://curriculum-content.s3.amazonaws.com/spring-mod-2/testing/spring-initializr-testing-project.png)
 
-```java
-package com.flatiron.spring.FlatironSpring;
+Once you have created the new project, let's create a few packages and classes.
+We'll start simple in this lesson and then continue to build and add more
+packages and classes as we go.
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+Create a package called `controller` under the `com.example.springtestingdemo`
+directory. In the `controller` directory, create a Java class called
+`DemoController`.
 
-import java.net.URL;
-import java.net.URLClassLoader;
+Consider the following project structure and ensure yours looks the same:
 
-@SpringBootApplication
-public class FlatironSpringApplication {
-
-	public static void main(String[] args) {
-		SpringApplication.run(FlatironSpringApplication.class, args);
-	}
-}
+```text
+├── HELP.md
+├── mvnw
+├── mvnw.cmd
+├── pom.xml
+└── src
+    ├── main
+    │   ├── java
+    │   │   └── com
+    │   │       └── example
+    │   │           └── springtestingdemo
+    │   │               ├── SpringTestingDemoApplication.java
+    │   │               └── controller
+    │   │                   └── DemoController.java
+    │   └── resources
+    │       ├── application.properties
+    │       ├── static
+    │       └── templates
+    └── test
+        └── java
+            └── org
+                └── example
+                    └── springtestingdemo
+                        └── SpringTestingDemoApplicationTests.java
 ```
 
-Let's add a basic endpoint to this application with the following class:
+Let's add a basic endpoint to this application. Add the following code to the
+`DemoController` class:
 
 ```java
-package com.flatiron.spring.FlatironSpring;
+package com.example.springtestingdemo.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class HelloController {
+public class DemoController {
 
-    @GetMapping("/hello")
-    public String hello() {
-        return "Hello World";
-    }
-
+   @GetMapping("/hello")
+   public String hello() {
+      return "Hello World";
+   }
 }
 ```
 
-Start your application, and you should now to be able to see the output of your
-endpoint in the console:
+If we start up the application and open up Postman, we should now be able to hit
+the `/hello` endpoint:
 
-![Hello World Console](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-hello-world-console.png)
+![postman-hello-world](https://curriculum-content.s3.amazonaws.com/spring-mod-2/testing/postman-hello-world.png)
 
-Or in the browser:
-
-![Hello World Browser](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-hello-world-browser.png)
-
-If you see an "unauthorized" error message instead of your "Hello World"
-message, you may be running into the configuration issue below. If so, go
-through the next session. If not, skip the next session and move on to the one
-after that.
-
-This is the login form you may see if security is automatically configured:
-
-![Spring Security Simple Authentication](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-simple-auth.png)
-
-### ! Configuration warning ! Putting Spring Security on hold until the next module
-
-Depending on the version of `Spring Boot` that you use, it may automatically add
-Spring Security to your classpath, in which case Spring will automatically
-configure a basic authenticator that will protect all URLs you try to expose
-through your application.
-
-While that is helpful once you understand how Spring Security works, we need to
-disable this functionality while we focus on testing. There are several ways to
-do this - we're going to use the easiest one here, and ignore the details of how
-this actually works until we discuss security in more details in another module.
-
-For now, simply add the following class to your existing package, and it will
-open up all your application URLs. We will cover exactly how and why that works
-in our Spring Security module.
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-
-@Configure
-@EnableWebSecurity
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-                .anyRequest().permitAll();
-    }
-}
-```
-
-### Back to our regular programming (see what we did there)
-
-Now that we have validated that our Spring setup is working properly, let's
-remove some of our functionality in order to make sure we can set up our testing
-properly to work **without** any Spring scaffolding.
-
-Let's start by commenting out the `@GetMapping` annotation in our
-`HelloController`:
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-public class HelloController {
-
-//    @GetMapping("/hello")
-    public String hello() {
-        return "Hello World";
-    }
-
-}
-```
-
-Restart your application, and you should see the following error message when
-you try to access your `/hello` URL:
-
-![URL not found](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-url-not-found.png)
-
-This validates that our `hello()` no longer defines an endpoint for our Spring
-application.
-
-Let's now create a test for our `HelloController` like we would if it wasn't
+Let's now create a test for our `DemoController` like we would if it wasn't
 part a Spring application:
 
-![Generate Test](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-generate-test.png)
+![intellij-generate-test](https://curriculum-content.s3.amazonaws.com/spring-mod-2/testing/intellij-generate-test.png)
 
 Let's add "Unit" to the name of this class to differentiate it from the
 integration and acceptance tests we will create later:
 
-![Unit Test Options](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-test-unit-test-options.png)
+![create-demo-controller-unit-test-class](https://curriculum-content.s3.amazonaws.com/spring-mod-2/testing/intellij-create-demo-controller-unit-test-class.png)
 
 In our unit test, we will simply test the return value of the method, just like
 we would for a method that is not part of a Spring application. Note that we
@@ -185,19 +117,19 @@ will first assert a wrong return value, just to validate that our test fails
 like it should, before actually changing it to test for the right return value:
 
 ```java
-package com.flatiron.spring.FlatironSpring;
+package com.example.springtestingdemo.controller;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class HelloControllerUnitTest {
+class DemoControllerUnitTest {
 
-    @Test
-    void hello() {
-        HelloController helloController = new HelloController();
-        assertEquals("Invalid Message", helloController.hello());
-    }
+   @Test
+   void hello() {
+      DemoController demoController = new DemoController();
+      assertEquals("Invalid Message", demoController.hello());
+   }
 }
 ```
 
@@ -205,105 +137,42 @@ Run this test and see that it fails as expected - the important part here is to
 make sure the test error is about the messages not matching, versus being about
 any configuration issues:
 
-![Hello Wrong Message](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-hello-wrong-message.png)
+![hello-wrong-message](https://curriculum-content.s3.amazonaws.com/spring-mod-2/testing/test-fail-1.png)
 
 Now change the assertion:
 
 ```java
-package com.flatiron.spring.FlatironSpring;
+package com.example.springtestingdemo.controller;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class HelloControllerUnitTest {
+class DemoControllerUnitTest {
 
-    @Test
-    void hello() {
-        HelloController helloController = new HelloController();
-        assertEquals("Hello World", helloController.hello());
-    }
+   @Test
+   void hello() {
+      DemoController demoController = new DemoController();
+      assertEquals("Hello World", demoController.hello());
+   }
 }
 ```
 
-And see that your test passes:
+When we re-run this test, it should now pass!
 
-![Hello test passes ](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-hello-test-passes.png)
-
-This method that returns a hardcoded value is not very valuable and not very
-interesting to test, so let's add a tiny bit of functionality to make it return
-a String that reflects a parameter that is passed in:
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-public class HelloController {
-
-//    @GetMapping("/hello")
-    public String hello(String name) {
-        return String.format("Hello %s", name);
-    }
-
-}
-```
-
-Our unit test will now fail, since we've changed the functionality of our method
-without updating it, so let's update it:
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class HelloControllerUnitTest {
-
-    @Test
-    void hello() {
-        HelloController helloController = new HelloController();
-        String name = "Jamie";
-        assertEquals("Hello " + name, helloController.hello(name));
-    }
-}
-```
-
-Now let's restore the endpoint functionality of the controller, and make sure
-that our unit test still passes without having to initialize any of the Spring
-framework components:
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-public class HelloController {
-
-    @GetMapping("/hello")
-    public String hello(String name) {
-        return String.format("Hello %s", name);
-    }
-
-}
-```
-
-You should now be able to run your unit test without any changes, and it should
-still pass.
+Note: This lesson does not follow the test driven development model, which is to
+write the unit tests first _before_ writing the code. In a test driven
+development model, we would have created the unit tests first.
 
 ## Conclusion
 
-In this section, we looked at how to set up a unit test in a Spring project that
+In this lesson, we reviewed how to set up a unit test in a Spring project that
 does **not** depend on nor care about any of the Spring Framework functionality.
-This allows us to have a suite of tests that are only focused on the actual
-functionality we've implemented in our application. These tests will be easier
-to diagnose if/when something breaks and will be very cheap to run in our
-day-to-day development process.
+It is very similar to how we created unit tests before. We should continue
+creating these types of tests when writing our Spring applications so that we
+have a suite of tests that are focused on the smallest pieces of functionality.
+These tests will be easier to diagnose if/when something breaks and will be very
+cheap to run in our day-to-day development process.
 
 We do, however, want to validate that our functionality is properly integrated
 with the Spring Framework, so that we can expose it as API endpoints for public

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Let's create a new Spring project to demonstrate testing within the Spring frame
    1. Click "ADD DEPENDENCIES".
    2. Search for "spring web".
    3. Select "Spring Web" from the list.
+   4. Click on "ADD DEPENDENCIES" again and add "Lombok" from the list.
 4. Click on the "Generate" button on the bottom. This will download a zip file
    containing the Spring Boot Project.
 5. Unzip the archive and open it in IntelliJ or a preferred code editor.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ the `/hello` endpoint:
 ![postman-hello-world](https://curriculum-content.s3.amazonaws.com/spring-mod-2/testing/postman-hello-world.png)
 
 Let's now create a test for our `DemoController` like we would if it wasn't
-part a Spring application:
+part of a Spring application:
 
 ![intellij-generate-test](https://curriculum-content.s3.amazonaws.com/spring-mod-2/testing/intellij-generate-test.png)
 

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ cheap to run in our day-to-day development process.
 
 We do, however, want to validate that our functionality is properly integrated
 with the Spring Framework, so that we can expose it as API endpoints for public
-or managed access. Let's look at that in the next section.
+or managed access. We'll look at that in the next couple of lessons.


### PR DESCRIPTION
This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.

This lesson really just needs to serve as a review to writing unit tests and that we can mostly write these unit tests regardless of the Spring Framework. I may come back to this lesson and add more... we'll see.